### PR TITLE
feat: add telemetry and analytics tracking

### DIFF
--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -397,3 +397,48 @@ This is the approach used by `gh` CLI, `lazygit`, `act`, and `age`.
 - [ ] Test `npm pack` and install from tarball locally
 - [ ] Tag release: `git tag v0.1.0 && git push --tags`
 - [ ] Set up npm 2FA for publish security
+- [ ] Set up PostHog telemetry (see below)
+
+---
+
+## Telemetry Setup Before Publishing
+
+> **Note:** Remove this section once PostHog is configured and the first publish is done.
+
+Remote telemetry requires a PostHog write-only project API key hardcoded in the default config. Without it, remote telemetry is silently skipped (local stats still work).
+
+### Steps:
+
+1. **Set up PostHog** (self-hosted or cloud free tier)
+2. **Get your project API key:**
+   - Go to **Project Settings > Project API Key**
+   - Copy the key (starts with `phc_`)
+3. **Add the key to `src/utils/config.ts`:**
+
+```typescript
+// In DEFAULT_CONFIG, replace the empty string:
+posthogApiKey: "phc_yourWriteOnlyKeyHere",
+```
+
+4. **If self-hosted, also update the host:**
+
+```typescript
+posthogHost: "https://your-posthog-instance.example.com",
+```
+
+5. **Build and publish:**
+
+```bash
+npm run build
+npm publish --tag beta
+```
+
+### What this enables:
+
+When anyone runs `dispatch run`, anonymous usage metrics (issue counts, PR counts, solve times, classification breakdown) are sent to your PostHog instance. No issue content, code, usernames, or tokens are ever transmitted.
+
+### Key facts:
+
+- The `phc_` key is **write-only** — safe to commit (same as Google Analytics IDs)
+- Users can opt out via config (`"telemetry": false`), CLI flag (`--no-telemetry`), or env var (`DISPATCH_NO_TELEMETRY=1`)
+- Local stats (`.dispatch/stats.json`) are always saved regardless

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ dispatch run --max-issues 5           # limit to 5 issues
 dispatch run --draft                  # create all PRs as drafts
 dispatch run --model opus             # use a specific model
 dispatch run --base-branch develop    # target a different base branch
+dispatch run --no-telemetry           # disable telemetry for this run
 ```
 
 **What happens:**
@@ -86,6 +87,25 @@ dispatch status          # pretty-printed morning report
 dispatch status --json   # raw JSON output
 ```
 
+### `dispatch stats`
+
+View cumulative statistics across all runs.
+
+```bash
+dispatch stats              # formatted dashboard
+dispatch stats --json       # raw JSON output
+dispatch stats --recent 5   # show last 5 runs
+```
+
+**Displays:**
+- Lifetime totals (issues checked, processed, solved, failed, PRs created)
+- Success rate and average solve time
+- Classification breakdown (bar chart)
+- Confidence distribution (1-10 histogram)
+- Engine usage breakdown
+- Failure categories
+- Recent runs table
+
 ### `dispatch init`
 
 Initialize configuration for your repository.
@@ -112,7 +132,10 @@ Dispatch reads `.dispatchrc.json` from your repo root:
   "autoLabel": true,
   "baseBranch": "main",
   "draftThreshold": 5,
-  "stateDir": ".dispatch"
+  "stateDir": ".dispatch",
+  "telemetry": true,
+  "posthogHost": "https://app.posthog.com",
+  "posthogApiKey": ""
 }
 ```
 
@@ -129,6 +152,9 @@ Dispatch reads `.dispatchrc.json` from your repo root:
 | `autoLabel` | Auto-label issues with classification | `true` |
 | `baseBranch` | Base branch for PRs | `main` |
 | `draftThreshold` | Confidence below this → draft PR | `5` |
+| `telemetry` | Enable anonymous usage analytics | `true` |
+| `posthogHost` | PostHog host URL (for self-hosted instances) | `https://app.posthog.com` |
+| `posthogApiKey` | PostHog project API key (write-only) | `""` |
 
 ## Issue Types
 
@@ -151,6 +177,31 @@ After solving each issue, the AI self-assesses its confidence (1-10):
 - **5-7**: Regular PR with "needs-review" notes
 - **1-4**: Draft PR — significant uncertainty, manual review essential
 
+## Telemetry & Privacy
+
+Dispatch collects anonymous usage analytics to help improve the tool. Telemetry is **enabled by default** and can be disabled at any time.
+
+**What's collected (anonymized):**
+- Aggregate counts: issues checked, processed, solved, failed, PRs created
+- Classification distribution and confidence scores
+- Solve times and generic failure categories (e.g. "timeout", "rate-limit")
+- Config settings: engine, model, concurrency, thresholds
+- Repo `owner/repo` (public GitHub info)
+
+**Never collected:**
+- Issue titles, body, comments, or code content
+- File paths, diffs, or error stack traces
+- GitHub usernames, emails, or tokens
+
+**Local stats** (`.dispatch/stats.json`) are always saved regardless of telemetry settings — they're private to your machine and power `dispatch stats`.
+
+**Opt-out methods:**
+- Config: `"telemetry": false` in `.dispatchrc.json`
+- CLI flag: `dispatch run --no-telemetry`
+- Environment variable: `DISPATCH_NO_TELEMETRY=1`
+
+**Self-hosted analytics:** Set `posthogHost` and `posthogApiKey` in your config to point to your own PostHog instance. Remote telemetry is skipped entirely if no API key is configured.
+
 ## Prerequisites
 
 - [Node.js](https://nodejs.org) >= 20
@@ -161,12 +212,13 @@ After solving each issue, the AI self-assesses its confidence (1-10):
 
 ```
 dispatch CLI
-├── Commands (run, create, status, init)
+├── Commands (run, create, status, stats, init)
 ├── GitHub Client (octokit — issues, PRs, labels)
 ├── Engine Layer (pluggable AI adapters)
 │   └── Claude Adapter (claude CLI --print)
 │   └── [Future] Gemini Adapter
 ├── Orchestrator (pipeline, classifier, planner, scorer)
+├── Telemetry (collector, local store, remote transport)
 ├── Reporter (morning summary, run history)
 └── Utils (config, git, logger)
 ```

--- a/bin/dispatch.ts
+++ b/bin/dispatch.ts
@@ -9,6 +9,7 @@ import { registerRunCommand } from "../src/commands/run.js";
 import { registerCreateCommand } from "../src/commands/create.js";
 import { registerStatusCommand } from "../src/commands/status.js";
 import { registerInitCommand } from "../src/commands/init.js";
+import { registerStatsCommand } from "../src/commands/stats.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "..", "..", "package.json"), "utf-8"));
@@ -30,6 +31,7 @@ registerRunCommand(program);
 registerCreateCommand(program);
 registerStatusCommand(program);
 registerInitCommand(program);
+registerStatsCommand(program);
 
 // Default action (no subcommand)
 program.action(() => {
@@ -47,6 +49,7 @@ program.action(() => {
   console.log(`  ${chalk.yellow("dispatch create")}     Create well-structured issues`);
   console.log(`  ${chalk.yellow("dispatch status")}     View last run summary`);
   console.log(`  ${chalk.yellow("dispatch init")}       Initialize config for this repo`);
+  console.log(`  ${chalk.yellow("dispatch stats")}      View historical run statistics`);
   console.log();
   console.log(chalk.gray("  Run dispatch --help for full options."));
   console.log();

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -78,6 +78,12 @@ export function registerInitCommand(program: Command) {
               message: "Create draft PRs by default?",
               default: false,
             },
+            {
+              type: "confirm",
+              name: "telemetry",
+              message: "Send anonymous usage analytics? (helps improve dispatch)",
+              default: true,
+            },
           ]);
 
           config = {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -21,6 +21,7 @@ export function registerRunCommand(program: Command) {
     .option("--draft", "Create all PRs as drafts")
     .option("--base-branch <branch>", "Base branch for PRs (default: main)")
     .option("--concurrency <n>", "Number of issues to process in parallel", parseInt)
+    .option("--no-telemetry", "Disable anonymous telemetry for this run")
     .action(async (options) => {
       try {
         const cwd = process.cwd();

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -1,0 +1,152 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { loadConfig } from "../utils/config.js";
+import { loadStats, type AggregateStats } from "../telemetry/store.js";
+import { log } from "../utils/logger.js";
+
+export function registerStatsCommand(program: Command) {
+  program
+    .command("stats")
+    .description("View historical dispatch statistics across all runs")
+    .option("--json", "Output as JSON")
+    .option("--recent <n>", "Show last N runs", parseInt)
+    .action(async (options) => {
+      try {
+        const cwd = process.cwd();
+        const config = await loadConfig(cwd);
+        const stats = await loadStats(cwd, config.stateDir);
+
+        if (stats.totalRuns === 0) {
+          log.info("No dispatch runs recorded yet.");
+          log.info(`Run ${chalk.yellow("dispatch run")} to get started.`);
+          return;
+        }
+
+        if (options.json) {
+          console.log(JSON.stringify(stats, null, 2));
+          return;
+        }
+
+        printStats(stats, options.recent);
+      } catch (err) {
+        log.error(`Stats failed: ${err instanceof Error ? err.message : err}`);
+        process.exit(1);
+      }
+    });
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.round(totalSeconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+function makeBar(value: number, max: number, width: number = 20): string {
+  const filled = max > 0 ? Math.round((value / max) * width) : 0;
+  return "\u2588".repeat(filled) + "\u2591".repeat(width - filled);
+}
+
+function printStats(stats: AggregateStats, recentCount?: number) {
+  console.log();
+  console.log(chalk.bold.cyan("  Dispatch Statistics"));
+  console.log(chalk.gray("  " + "\u2501".repeat(40)));
+  console.log();
+
+  // Date range
+  const first = stats.firstRunAt ? stats.firstRunAt.split("T")[0] : "—";
+  const last = stats.lastRunAt ? stats.lastRunAt.split("T")[0] : "—";
+  console.log(chalk.gray(`  ${stats.totalRuns} runs from ${first} to ${last}`));
+  console.log();
+
+  // Totals
+  console.log(chalk.bold("  Totals"));
+  console.log(`    Issues checked:     ${chalk.white(String(stats.totalIssuesChecked))}`);
+  console.log(`    Issues processed:   ${chalk.white(String(stats.totalIssuesProcessed))}`);
+  console.log(`    Issues solved:      ${chalk.green(String(stats.totalIssuesSolved))}`);
+  console.log(`    Issues failed:      ${chalk.red(String(stats.totalIssuesFailed))}`);
+  console.log(`    PRs created:        ${chalk.cyan(String(stats.totalPRsCreated))}`);
+  console.log(`    Total time:         ${chalk.gray(formatDuration(stats.totalDurationMs))}`);
+
+  if (stats.totalIssuesProcessed > 0) {
+    const successRate = ((stats.totalIssuesSolved / stats.totalIssuesProcessed) * 100).toFixed(1);
+    console.log(`    Success rate:       ${chalk.yellow(successRate + "%")}`);
+  }
+  if (stats.avgSolveTimeMs > 0) {
+    console.log(`    Avg solve time:     ${chalk.gray(formatDuration(stats.avgSolveTimeMs))}`);
+  }
+  console.log();
+
+  // Classification breakdown
+  const classEntries = Object.entries(stats.classificationBreakdown).sort((a, b) => b[1] - a[1]);
+  if (classEntries.length > 0) {
+    console.log(chalk.bold("  Classification Breakdown"));
+    const maxCount = Math.max(...classEntries.map(([, v]) => v));
+    for (const [cls, count] of classEntries) {
+      const bar = makeBar(count, maxCount, 20);
+      const pct = ((count / stats.totalIssuesProcessed) * 100).toFixed(1);
+      console.log(`    ${cls.padEnd(16)} ${chalk.cyan(bar)} ${count} (${pct}%)`);
+    }
+    console.log();
+  }
+
+  // Confidence distribution
+  const confEntries = Object.entries(stats.confidenceHistogram)
+    .map(([k, v]) => [Number(k), v] as [number, number])
+    .sort((a, b) => a[0] - b[0]);
+  if (confEntries.length > 0) {
+    console.log(chalk.bold("  Confidence Distribution"));
+    const maxConf = Math.max(...confEntries.map(([, v]) => v));
+    for (const [score, count] of confEntries) {
+      const bar = makeBar(count, maxConf, 20);
+      console.log(`    ${String(score).padStart(2)}/10  ${chalk.green(bar)} ${count}`);
+    }
+    console.log();
+  }
+
+  // Engine usage
+  const engineEntries = Object.entries(stats.engineUsage).sort((a, b) => b[1] - a[1]);
+  if (engineEntries.length > 0) {
+    console.log(chalk.bold("  Engine Usage"));
+    const maxEngine = Math.max(...engineEntries.map(([, v]) => v));
+    for (const [eng, count] of engineEntries) {
+      const bar = makeBar(count, maxEngine, 20);
+      console.log(`    ${eng.padEnd(16)} ${chalk.yellow(bar)} ${count} runs`);
+    }
+    console.log();
+  }
+
+  // Failure categories
+  const failEntries = Object.entries(stats.failureCategoryBreakdown).sort((a, b) => b[1] - a[1]);
+  if (failEntries.length > 0) {
+    console.log(chalk.bold("  Failure Categories"));
+    const totalFailures = failEntries.reduce((sum, [, v]) => sum + v, 0);
+    for (const [cat, count] of failEntries) {
+      const pct = ((count / totalFailures) * 100).toFixed(1);
+      console.log(`    ${chalk.red(cat.padEnd(20))} ${count} (${pct}%)`);
+    }
+    console.log();
+  }
+
+  // Recent runs
+  const recentLimit = recentCount || 10;
+  const recentRuns = stats.recentRuns.slice(-recentLimit).reverse();
+  if (recentRuns.length > 0) {
+    console.log(chalk.bold(`  Recent Runs (last ${recentRuns.length})`));
+    for (const run of recentRuns) {
+      const date = run.timestamp.split("T")[0];
+      const duration = formatDuration(run.durationMs);
+      console.log(
+        `    ${chalk.gray(date)}  ` +
+        `${run.issuesProcessed} processed, ` +
+        `${chalk.green(String(run.issuesSolved))} solved, ` +
+        `${chalk.cyan(String(run.prsCreated))} PRs  ` +
+        chalk.gray(`(${duration})`)
+      );
+    }
+    console.log();
+  }
+}

--- a/src/orchestrator/pipeline.ts
+++ b/src/orchestrator/pipeline.ts
@@ -15,6 +15,9 @@ import { heuristicClassify } from "../orchestrator/classifier.js";
 import { adjustConfidence } from "../orchestrator/scorer.js";
 import { Semaphore } from "../utils/semaphore.js";
 import { createWorktree, removeWorktree, getWorktreePath, cleanupAllWorktrees } from "../utils/worktree.js";
+import { TelemetryCollector } from "../telemetry/collector.js";
+import { getAnonymousId, sendTelemetryEvent } from "../telemetry/remote.js";
+import { updateStats } from "../telemetry/store.js";
 
 export interface PipelineOptions {
   config: DispatchConfig;
@@ -27,6 +30,7 @@ export interface PipelineOptions {
 export async function runPipeline(options: PipelineOptions): Promise<RunSummary> {
   const { config, engine, github, cwd, dryRun = false } = options;
   const startTime = Date.now();
+  const telemetry = new TelemetryCollector();
 
   // Initialize file-based logging
   await initFileLogging(config.stateDir, cwd);
@@ -43,6 +47,8 @@ export async function runPipeline(options: PipelineOptions): Promise<RunSummary>
     excludeLabels: config.exclude,
     maxIssues: config.maxIssues,
   });
+
+  telemetry.recordIssuesChecked(allIssues.length);
 
   if (allIssues.length === 0) {
     log.info("No issues to process. All done! 🎉");
@@ -125,6 +131,7 @@ export async function runPipeline(options: PipelineOptions): Promise<RunSummary>
     const branchName = `${config.branchPrefix}issue-${issue.number}-${slugifyTitle(issue.title)}`;
     const worktreePath = getWorktreePath(cwd, config.stateDir, issue.number);
     let issueStatus: "solved" | "failed" | "no-changes" = "failed";
+    const issueStartTime = Date.now();
 
     try {
       log.info(`[#${issue.number}] ${issue.title} (${issue.classification || "unknown"})`);
@@ -137,6 +144,7 @@ export async function runPipeline(options: PipelineOptions): Promise<RunSummary>
       );
 
       const solveStart = Date.now();
+      telemetry.startSolve(issue.number);
       log.info(`[#${issue.number}] Solving...`);
 
       const progressInterval = setInterval(() => {
@@ -182,6 +190,18 @@ export async function runPipeline(options: PipelineOptions): Promise<RunSummary>
       if (!hasChanges) {
         log.warn(`[#${issue.number}] No changes produced`);
         issueStatus = "no-changes";
+
+        const solveTimeMs = Date.now() - solveStart;
+        telemetry.recordIssue({
+          issueNumber: issue.number,
+          classification: issue.classification || "unknown",
+          confidence: result.confidence,
+          solveTimeMs,
+          status: "no-changes",
+          changedFileCount: 0,
+          isInvestigation,
+        });
+
         issueSummaries.push({
           number: issue.number,
           title: issue.title,
@@ -211,6 +231,18 @@ export async function runPipeline(options: PipelineOptions): Promise<RunSummary>
       }
 
       issueStatus = "solved";
+
+      const solveTimeMs = Date.now() - solveStart;
+      telemetry.recordIssue({
+        issueNumber: issue.number,
+        classification: issue.classification || "unknown",
+        confidence: result.confidence,
+        solveTimeMs,
+        status: "solved",
+        changedFileCount: result.changedFiles.length,
+        isInvestigation,
+      });
+
       issueSummaries.push({
         number: issue.number,
         title: issue.title,
@@ -226,6 +258,20 @@ export async function runPipeline(options: PipelineOptions): Promise<RunSummary>
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
       log.error(`[#${issue.number}] Failed: ${errorMsg}`);
+
+      const solveTimeMs = Date.now() - issueStartTime;
+      telemetry.recordIssue({
+        issueNumber: issue.number,
+        classification: issue.classification || "unknown",
+        confidence: null,
+        solveTimeMs,
+        status: "failed",
+        failureReason: errorMsg,
+        changedFileCount: 0,
+        isInvestigation: ["investigation", "audit", "documentation"].includes(
+          issue.classification || ""
+        ),
+      });
 
       issueSummaries.push({
         number: issue.number,
@@ -263,6 +309,36 @@ export async function runPipeline(options: PipelineOptions): Promise<RunSummary>
 
   await saveSummary(summary, cwd, config.stateDir);
   printSummary(summary);
+
+  // Telemetry: save local stats and optionally send remote event
+  try {
+    const anonymousId = await getAnonymousId(cwd, config.stateDir);
+    const event = telemetry.buildEvent({
+      anonymousId,
+      startedAt: summary.startedAt,
+      durationMs: summary.duration,
+      repoOwner: github.owner,
+      repoName: github.repo,
+      engine: config.engine,
+      model: config.model,
+      concurrency: config.concurrency,
+      maxIssues: config.maxIssues,
+      maxTurnsPerIssue: config.maxTurnsPerIssue,
+      draftThreshold: config.draftThreshold,
+      createDraftPRs: config.createDraftPRs,
+      prsCreated: summary.prsCreated.length,
+    });
+
+    // Always save local stats
+    await updateStats(event, cwd, config.stateDir);
+
+    // Remote send only if telemetry is enabled
+    if (config.telemetry) {
+      sendTelemetryEvent(event);
+    }
+  } catch (err) {
+    log.debug(`Telemetry finalization failed (non-fatal): ${err}`);
+  }
 
   return summary;
 }

--- a/src/orchestrator/pipeline.ts
+++ b/src/orchestrator/pipeline.ts
@@ -334,7 +334,7 @@ export async function runPipeline(options: PipelineOptions): Promise<RunSummary>
 
     // Remote send only if telemetry is enabled
     if (config.telemetry) {
-      sendTelemetryEvent(event);
+      sendTelemetryEvent(event, config.posthogHost, config.posthogApiKey);
     }
   } catch (err) {
     log.debug(`Telemetry finalization failed (non-fatal): ${err}`);

--- a/src/telemetry/collector.ts
+++ b/src/telemetry/collector.ts
@@ -1,0 +1,160 @@
+import type { IssueClassification } from "../engine/types.js";
+
+/** Per-issue telemetry record */
+export interface IssueTelemetry {
+  issueNumber: number;
+  classification: IssueClassification | "unknown";
+  confidence: number | null;
+  solveTimeMs: number;
+  status: "solved" | "failed" | "no-changes" | "skipped";
+  failureReason?: string;
+  changedFileCount: number;
+  isInvestigation: boolean;
+}
+
+/** Aggregate run telemetry event */
+export interface RunTelemetryEvent {
+  anonymousId: string;
+  eventType: "run_completed";
+  timestamp: string;
+  durationMs: number;
+
+  repoOwner: string;
+  repoName: string;
+
+  engine: string;
+  model: string;
+  concurrency: number;
+  maxIssues: number;
+  maxTurnsPerIssue: number;
+  draftThreshold: number;
+  createDraftPRs: boolean;
+
+  issuesChecked: number;
+  issuesProcessed: number;
+  issuesSolved: number;
+  issuesFailed: number;
+  issuesNoChanges: number;
+  prsCreated: number;
+
+  classificationBreakdown: Record<string, number>;
+  confidenceScores: number[];
+  solveTimes: number[];
+  failureCategories: string[];
+
+  avgChangedFiles: number;
+  investigationCount: number;
+}
+
+/** Categorize a failure reason into a generic bucket (no PII) */
+export function categorizeFailure(error: string): string {
+  const lower = error.toLowerCase();
+  if (lower.includes("timeout")) return "timeout";
+  if (lower.includes("rate limit") || lower.includes("ratelimit")) return "rate-limit";
+  if (lower.includes("token") || lower.includes("auth")) return "auth-error";
+  if (lower.includes("parse") || lower.includes("json")) return "parse-error";
+  if (lower.includes("spawn") || lower.includes("enoent")) return "engine-not-found";
+  if (lower.includes("network") || lower.includes("fetch")) return "network-error";
+  return "unknown-error";
+}
+
+/** Collects metrics during a single pipeline run */
+export class TelemetryCollector {
+  private issues: IssueTelemetry[] = [];
+  private issuesCheckedCount = 0;
+  private solveStartTimes = new Map<number, number>();
+
+  /** Record the total number of issues fetched from GitHub */
+  recordIssuesChecked(count: number): void {
+    this.issuesCheckedCount = count;
+  }
+
+  /** Mark the start of solving an issue (for timing) */
+  startSolve(issueNumber: number): void {
+    this.solveStartTimes.set(issueNumber, Date.now());
+  }
+
+  /** Get the start time for an issue solve */
+  getSolveStartTime(issueNumber: number): number | undefined {
+    return this.solveStartTimes.get(issueNumber);
+  }
+
+  /** Record the outcome of processing a single issue */
+  recordIssue(telemetry: IssueTelemetry): void {
+    this.issues.push(telemetry);
+  }
+
+  /** Build the final telemetry event for the completed run */
+  buildEvent(params: {
+    anonymousId: string;
+    startedAt: string;
+    durationMs: number;
+    repoOwner: string;
+    repoName: string;
+    engine: string;
+    model: string;
+    concurrency: number;
+    maxIssues: number;
+    maxTurnsPerIssue: number;
+    draftThreshold: number;
+    createDraftPRs: boolean;
+    prsCreated: number;
+  }): RunTelemetryEvent {
+    const classificationBreakdown: Record<string, number> = {};
+    const confidenceScores: number[] = [];
+    const solveTimes: number[] = [];
+    const failureCategories: string[] = [];
+    let totalChangedFiles = 0;
+    let investigationCount = 0;
+
+    for (const issue of this.issues) {
+      const cls = issue.classification || "unknown";
+      classificationBreakdown[cls] = (classificationBreakdown[cls] || 0) + 1;
+
+      if (issue.confidence !== null) {
+        confidenceScores.push(issue.confidence);
+      }
+
+      if (issue.solveTimeMs > 0) {
+        solveTimes.push(issue.solveTimeMs);
+      }
+
+      if (issue.status === "failed" && issue.failureReason) {
+        failureCategories.push(categorizeFailure(issue.failureReason));
+      }
+
+      totalChangedFiles += issue.changedFileCount;
+      if (issue.isInvestigation) investigationCount++;
+    }
+
+    return {
+      anonymousId: params.anonymousId,
+      eventType: "run_completed",
+      timestamp: params.startedAt,
+      durationMs: params.durationMs,
+      repoOwner: params.repoOwner,
+      repoName: params.repoName,
+      engine: params.engine,
+      model: params.model,
+      concurrency: params.concurrency,
+      maxIssues: params.maxIssues,
+      maxTurnsPerIssue: params.maxTurnsPerIssue,
+      draftThreshold: params.draftThreshold,
+      createDraftPRs: params.createDraftPRs,
+      issuesChecked: this.issuesCheckedCount,
+      issuesProcessed: this.issues.filter((i) => i.status !== "skipped").length,
+      issuesSolved: this.issues.filter((i) => i.status === "solved").length,
+      issuesFailed: this.issues.filter((i) => i.status === "failed").length,
+      issuesNoChanges: this.issues.filter((i) => i.status === "no-changes").length,
+      prsCreated: params.prsCreated,
+      classificationBreakdown,
+      confidenceScores,
+      solveTimes,
+      failureCategories,
+      avgChangedFiles: this.issues.length > 0
+        ? totalChangedFiles / this.issues.length
+        : 0,
+      investigationCount,
+    };
+  }
+}

--- a/src/telemetry/remote.ts
+++ b/src/telemetry/remote.ts
@@ -1,0 +1,77 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import type { RunTelemetryEvent } from "./collector.js";
+import { log } from "../utils/logger.js";
+
+const TELEMETRY_ID_FILE = "telemetry-id.json";
+
+// PostHog configuration — write-only key, safe to embed in client code
+const POSTHOG_HOST = "https://app.posthog.com";
+const POSTHOG_API_KEY = "phc_PLACEHOLDER_REPLACE_WITH_REAL_KEY";
+
+/** Get or create a stable anonymous ID for this installation */
+export async function getAnonymousId(cwd: string, stateDir: string): Promise<string> {
+  const dir = join(cwd, stateDir);
+  const filePath = join(dir, TELEMETRY_ID_FILE);
+
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    const data = JSON.parse(raw);
+    if (data.id) return data.id as string;
+  } catch {
+    // File doesn't exist, create one
+  }
+
+  const id = randomUUID();
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    filePath,
+    JSON.stringify({ id, createdAt: new Date().toISOString() }, null, 2) + "\n",
+    "utf-8",
+  );
+  return id;
+}
+
+/** Send telemetry event to PostHog. Fire-and-forget, never throws. */
+export function sendTelemetryEvent(event: RunTelemetryEvent): void {
+  const payload = {
+    api_key: POSTHOG_API_KEY,
+    event: event.eventType,
+    distinct_id: event.anonymousId,
+    timestamp: event.timestamp,
+    properties: {
+      repo_owner: event.repoOwner,
+      repo_name: event.repoName,
+      engine: event.engine,
+      model: event.model,
+      concurrency: event.concurrency,
+      max_issues: event.maxIssues,
+      max_turns_per_issue: event.maxTurnsPerIssue,
+      draft_threshold: event.draftThreshold,
+      create_draft_prs: event.createDraftPRs,
+      issues_checked: event.issuesChecked,
+      issues_processed: event.issuesProcessed,
+      issues_solved: event.issuesSolved,
+      issues_failed: event.issuesFailed,
+      issues_no_changes: event.issuesNoChanges,
+      prs_created: event.prsCreated,
+      classification_breakdown: event.classificationBreakdown,
+      confidence_scores: event.confidenceScores,
+      solve_times_ms: event.solveTimes,
+      failure_categories: event.failureCategories,
+      avg_changed_files: event.avgChangedFiles,
+      investigation_count: event.investigationCount,
+      duration_ms: event.durationMs,
+    },
+  };
+
+  fetch(`${POSTHOG_HOST}/capture/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(5000),
+  }).catch((err) => {
+    log.debug(`Telemetry send failed (non-fatal): ${err}`);
+  });
+}

--- a/src/telemetry/remote.ts
+++ b/src/telemetry/remote.ts
@@ -6,10 +6,6 @@ import { log } from "../utils/logger.js";
 
 const TELEMETRY_ID_FILE = "telemetry-id.json";
 
-// PostHog configuration — write-only key, safe to embed in client code
-const POSTHOG_HOST = "https://app.posthog.com";
-const POSTHOG_API_KEY = "phc_PLACEHOLDER_REPLACE_WITH_REAL_KEY";
-
 /** Get or create a stable anonymous ID for this installation */
 export async function getAnonymousId(cwd: string, stateDir: string): Promise<string> {
   const dir = join(cwd, stateDir);
@@ -33,10 +29,21 @@ export async function getAnonymousId(cwd: string, stateDir: string): Promise<str
   return id;
 }
 
-/** Send telemetry event to PostHog. Fire-and-forget, never throws. */
-export function sendTelemetryEvent(event: RunTelemetryEvent): void {
+/** Send telemetry event to PostHog (self-hosted or cloud). Fire-and-forget, never throws. */
+export function sendTelemetryEvent(
+  event: RunTelemetryEvent,
+  posthogHost: string,
+  posthogApiKey: string,
+): void {
+  if (!posthogApiKey) {
+    log.debug("Telemetry: no PostHog API key configured, skipping remote send");
+    return;
+  }
+
+  const host = posthogHost.replace(/\/+$/, ""); // strip trailing slashes
+
   const payload = {
-    api_key: POSTHOG_API_KEY,
+    api_key: posthogApiKey,
     event: event.eventType,
     distinct_id: event.anonymousId,
     timestamp: event.timestamp,
@@ -66,7 +73,7 @@ export function sendTelemetryEvent(event: RunTelemetryEvent): void {
     },
   };
 
-  fetch(`${POSTHOG_HOST}/capture/`, {
+  fetch(`${host}/capture/`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),

--- a/src/telemetry/store.ts
+++ b/src/telemetry/store.ts
@@ -1,0 +1,122 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import type { RunTelemetryEvent } from "./collector.js";
+
+/** Cumulative statistics stored in .dispatch/stats.json */
+export interface AggregateStats {
+  version: 1;
+  firstRunAt: string;
+  lastRunAt: string;
+  totalRuns: number;
+  totalIssuesChecked: number;
+  totalIssuesProcessed: number;
+  totalIssuesSolved: number;
+  totalIssuesFailed: number;
+  totalPRsCreated: number;
+  totalDurationMs: number;
+  classificationBreakdown: Record<string, number>;
+  confidenceHistogram: Record<string, number>;
+  engineUsage: Record<string, number>;
+  avgSolveTimeMs: number;
+  failureCategoryBreakdown: Record<string, number>;
+  recentRuns: Array<{
+    timestamp: string;
+    issuesProcessed: number;
+    issuesSolved: number;
+    prsCreated: number;
+    durationMs: number;
+  }>;
+}
+
+const STATS_FILENAME = "stats.json";
+const MAX_RECENT_RUNS = 50;
+
+function emptyStats(): AggregateStats {
+  return {
+    version: 1,
+    firstRunAt: "",
+    lastRunAt: "",
+    totalRuns: 0,
+    totalIssuesChecked: 0,
+    totalIssuesProcessed: 0,
+    totalIssuesSolved: 0,
+    totalIssuesFailed: 0,
+    totalPRsCreated: 0,
+    totalDurationMs: 0,
+    classificationBreakdown: {},
+    confidenceHistogram: {},
+    engineUsage: {},
+    avgSolveTimeMs: 0,
+    failureCategoryBreakdown: {},
+    recentRuns: [],
+  };
+}
+
+export async function loadStats(cwd: string, stateDir: string): Promise<AggregateStats> {
+  try {
+    const filePath = join(cwd, stateDir, STATS_FILENAME);
+    const raw = await readFile(filePath, "utf-8");
+    return JSON.parse(raw) as AggregateStats;
+  } catch {
+    return emptyStats();
+  }
+}
+
+export async function updateStats(
+  event: RunTelemetryEvent,
+  cwd: string,
+  stateDir: string,
+): Promise<void> {
+  const stats = await loadStats(cwd, stateDir);
+
+  if (!stats.firstRunAt) stats.firstRunAt = event.timestamp;
+  stats.lastRunAt = event.timestamp;
+  stats.totalRuns++;
+  stats.totalIssuesChecked += event.issuesChecked;
+  stats.totalIssuesProcessed += event.issuesProcessed;
+  stats.totalIssuesSolved += event.issuesSolved;
+  stats.totalIssuesFailed += event.issuesFailed;
+  stats.totalPRsCreated += event.prsCreated;
+  stats.totalDurationMs += event.durationMs;
+
+  for (const [cls, count] of Object.entries(event.classificationBreakdown)) {
+    stats.classificationBreakdown[cls] = (stats.classificationBreakdown[cls] || 0) + count;
+  }
+
+  for (const score of event.confidenceScores) {
+    const key = String(Math.round(score));
+    stats.confidenceHistogram[key] = (stats.confidenceHistogram[key] || 0) + 1;
+  }
+
+  const engineKey = `${event.engine}:${event.model}`;
+  stats.engineUsage[engineKey] = (stats.engineUsage[engineKey] || 0) + 1;
+
+  const totalSolveSamples = event.solveTimes.length;
+  if (totalSolveSamples > 0) {
+    const newAvg = event.solveTimes.reduce((a, b) => a + b, 0) / totalSolveSamples;
+    const prevWeight = Math.max(0, stats.totalRuns - 1);
+    stats.avgSolveTimeMs = prevWeight > 0
+      ? (stats.avgSolveTimeMs * prevWeight + newAvg) / stats.totalRuns
+      : newAvg;
+  }
+
+  for (const cat of event.failureCategories) {
+    stats.failureCategoryBreakdown[cat] = (stats.failureCategoryBreakdown[cat] || 0) + 1;
+  }
+
+  stats.recentRuns.push({
+    timestamp: event.timestamp,
+    issuesProcessed: event.issuesProcessed,
+    issuesSolved: event.issuesSolved,
+    prsCreated: event.prsCreated,
+    durationMs: event.durationMs,
+  });
+  if (stats.recentRuns.length > MAX_RECENT_RUNS) {
+    stats.recentRuns = stats.recentRuns.slice(-MAX_RECENT_RUNS);
+  }
+
+  const dir = join(cwd, stateDir);
+  await mkdir(dir, { recursive: true });
+  const filePath = join(dir, STATS_FILENAME);
+  await writeFile(filePath, JSON.stringify(stats, null, 2) + "\n", "utf-8");
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -30,6 +30,8 @@ export interface DispatchConfig {
   timeoutPerIssue: number;
   /** Number of issues to process in parallel (default: 3) */
   concurrency: number;
+  /** Enable anonymous telemetry (default: true). Set to false to opt out of remote analytics. */
+  telemetry: boolean;
 }
 
 const DEFAULT_CONFIG: DispatchConfig = {
@@ -47,6 +49,7 @@ const DEFAULT_CONFIG: DispatchConfig = {
   stateDir: ".dispatch",
   timeoutPerIssue: 10 * 60 * 1000, // 10 minutes
   concurrency: 3,
+  telemetry: true,
 };
 
 const CONFIG_FILENAME = ".dispatchrc.json";
@@ -58,9 +61,13 @@ export async function loadConfig(cwd: string = process.cwd()): Promise<DispatchC
     await access(configPath);
     const raw = await readFile(configPath, "utf-8");
     const fileConfig = JSON.parse(raw) as Partial<DispatchConfig>;
-    return { ...DEFAULT_CONFIG, ...fileConfig };
+    const config = { ...DEFAULT_CONFIG, ...fileConfig };
+    if (process.env.DISPATCH_NO_TELEMETRY === "1") config.telemetry = false;
+    return config;
   } catch {
-    return { ...DEFAULT_CONFIG };
+    const config = { ...DEFAULT_CONFIG };
+    if (process.env.DISPATCH_NO_TELEMETRY === "1") config.telemetry = false;
+    return config;
   }
 }
 
@@ -82,6 +89,7 @@ export function applyCliOverrides(config: DispatchConfig, options: Record<string
   if (options.draft !== undefined) merged.createDraftPRs = Boolean(options.draft);
   if (options.baseBranch) merged.baseBranch = String(options.baseBranch);
   if (options.concurrency) merged.concurrency = Number(options.concurrency);
+  if (options.noTelemetry) merged.telemetry = false;
 
   return merged;
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -32,6 +32,10 @@ export interface DispatchConfig {
   concurrency: number;
   /** Enable anonymous telemetry (default: true). Set to false to opt out of remote analytics. */
   telemetry: boolean;
+  /** PostHog host URL for self-hosted instances (default: https://app.posthog.com) */
+  posthogHost: string;
+  /** PostHog project API key (write-only). Required for remote telemetry. */
+  posthogApiKey: string;
 }
 
 const DEFAULT_CONFIG: DispatchConfig = {
@@ -50,6 +54,8 @@ const DEFAULT_CONFIG: DispatchConfig = {
   timeoutPerIssue: 10 * 60 * 1000, // 10 minutes
   concurrency: 3,
   telemetry: true,
+  posthogHost: "https://app.posthog.com",
+  posthogApiKey: "",
 };
 
 const CONFIG_FILENAME = ".dispatchrc.json";

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -1,0 +1,204 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { TelemetryCollector, categorizeFailure } from "../src/telemetry/collector.js";
+
+describe("TelemetryCollector", () => {
+  it("records issues checked count", () => {
+    const collector = new TelemetryCollector();
+    collector.recordIssuesChecked(15);
+
+    const event = collector.buildEvent({
+      anonymousId: "test-id",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      durationMs: 1000,
+      repoOwner: "owner",
+      repoName: "repo",
+      engine: "claude",
+      model: "sonnet",
+      concurrency: 3,
+      maxIssues: 10,
+      maxTurnsPerIssue: 10,
+      draftThreshold: 5,
+      createDraftPRs: false,
+      prsCreated: 0,
+    });
+
+    assert.equal(event.issuesChecked, 15);
+  });
+
+  it("records and aggregates issue telemetry", () => {
+    const collector = new TelemetryCollector();
+    collector.recordIssuesChecked(3);
+
+    collector.recordIssue({
+      issueNumber: 1,
+      classification: "code-fix",
+      confidence: 8,
+      solveTimeMs: 5000,
+      status: "solved",
+      changedFileCount: 2,
+      isInvestigation: false,
+    });
+
+    collector.recordIssue({
+      issueNumber: 2,
+      classification: "feature",
+      confidence: 6,
+      solveTimeMs: 8000,
+      status: "solved",
+      changedFileCount: 5,
+      isInvestigation: false,
+    });
+
+    collector.recordIssue({
+      issueNumber: 3,
+      classification: "code-fix",
+      confidence: null,
+      solveTimeMs: 2000,
+      status: "failed",
+      failureReason: "timeout exceeded",
+      changedFileCount: 0,
+      isInvestigation: false,
+    });
+
+    const event = collector.buildEvent({
+      anonymousId: "test-id",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      durationMs: 15000,
+      repoOwner: "owner",
+      repoName: "repo",
+      engine: "claude",
+      model: "sonnet",
+      concurrency: 3,
+      maxIssues: 10,
+      maxTurnsPerIssue: 10,
+      draftThreshold: 5,
+      createDraftPRs: false,
+      prsCreated: 2,
+    });
+
+    assert.equal(event.issuesProcessed, 3);
+    assert.equal(event.issuesSolved, 2);
+    assert.equal(event.issuesFailed, 1);
+    assert.equal(event.issuesNoChanges, 0);
+    assert.equal(event.prsCreated, 2);
+    assert.deepEqual(event.classificationBreakdown, { "code-fix": 2, feature: 1 });
+    assert.deepEqual(event.confidenceScores, [8, 6]);
+    assert.deepEqual(event.solveTimes, [5000, 8000, 2000]);
+    assert.deepEqual(event.failureCategories, ["timeout"]);
+    assert.equal(event.avgChangedFiles, 7 / 3);
+    assert.equal(event.investigationCount, 0);
+  });
+
+  it("tracks investigation count", () => {
+    const collector = new TelemetryCollector();
+    collector.recordIssuesChecked(2);
+
+    collector.recordIssue({
+      issueNumber: 1,
+      classification: "investigation",
+      confidence: 5,
+      solveTimeMs: 3000,
+      status: "solved",
+      changedFileCount: 1,
+      isInvestigation: true,
+    });
+
+    collector.recordIssue({
+      issueNumber: 2,
+      classification: "code-fix",
+      confidence: 7,
+      solveTimeMs: 4000,
+      status: "solved",
+      changedFileCount: 3,
+      isInvestigation: false,
+    });
+
+    const event = collector.buildEvent({
+      anonymousId: "test-id",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      durationMs: 7000,
+      repoOwner: "owner",
+      repoName: "repo",
+      engine: "claude",
+      model: "sonnet",
+      concurrency: 3,
+      maxIssues: 10,
+      maxTurnsPerIssue: 10,
+      draftThreshold: 5,
+      createDraftPRs: false,
+      prsCreated: 2,
+    });
+
+    assert.equal(event.investigationCount, 1);
+  });
+
+  it("handles empty collector", () => {
+    const collector = new TelemetryCollector();
+    collector.recordIssuesChecked(0);
+
+    const event = collector.buildEvent({
+      anonymousId: "test-id",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      durationMs: 100,
+      repoOwner: "owner",
+      repoName: "repo",
+      engine: "claude",
+      model: "sonnet",
+      concurrency: 3,
+      maxIssues: 10,
+      maxTurnsPerIssue: 10,
+      draftThreshold: 5,
+      createDraftPRs: false,
+      prsCreated: 0,
+    });
+
+    assert.equal(event.issuesChecked, 0);
+    assert.equal(event.issuesProcessed, 0);
+    assert.equal(event.avgChangedFiles, 0);
+    assert.deepEqual(event.classificationBreakdown, {});
+  });
+
+  it("tracks solve start times", () => {
+    const collector = new TelemetryCollector();
+    collector.startSolve(42);
+    const startTime = collector.getSolveStartTime(42);
+    assert.ok(startTime !== undefined);
+    assert.ok(startTime <= Date.now());
+  });
+});
+
+describe("categorizeFailure", () => {
+  it("maps timeout errors", () => {
+    assert.equal(categorizeFailure("Operation timeout exceeded"), "timeout");
+  });
+
+  it("maps rate limit errors", () => {
+    assert.equal(categorizeFailure("GitHub rate limit reached"), "rate-limit");
+    assert.equal(categorizeFailure("API ratelimit exceeded"), "rate-limit");
+  });
+
+  it("maps auth errors", () => {
+    assert.equal(categorizeFailure("Bad token: unauthorized"), "auth-error");
+    assert.equal(categorizeFailure("Authentication failed"), "auth-error");
+  });
+
+  it("maps parse errors", () => {
+    assert.equal(categorizeFailure("JSON parse error"), "parse-error");
+    assert.equal(categorizeFailure("Failed to parse response"), "parse-error");
+  });
+
+  it("maps engine-not-found errors", () => {
+    assert.equal(categorizeFailure("spawn ENOENT"), "engine-not-found");
+    assert.equal(categorizeFailure("Could not spawn process"), "engine-not-found");
+  });
+
+  it("maps network errors", () => {
+    assert.equal(categorizeFailure("Network error: connection refused"), "network-error");
+    assert.equal(categorizeFailure("fetch failed"), "network-error");
+  });
+
+  it("returns unknown-error for unmatched", () => {
+    assert.equal(categorizeFailure("something unexpected happened"), "unknown-error");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds anonymous telemetry collection with PostHog integration
- Adds local stats persistence in `.dispatch/stats.json`
- Adds `dispatch stats` CLI command for viewing historical run statistics
- Adds configurable PostHog host/API key for self-hosted instances
- Adds telemetry docs to README and PUBLISH

## Note
This branch also contains unrelated file deletions (schedule, gemini, github-models engines, etc.) that should **not** be merged. The telemetry feature has already been cleanly cherry-picked onto main in commit `6fd0f0e`. This PR is for tracking/reference purposes.

## Opt-out options
- `--no-telemetry` CLI flag
- `"telemetry": false` in `.dispatchrc.json`
- `DISPATCH_NO_TELEMETRY=1` env var